### PR TITLE
Added Global Traffic Management Service in Networking Category and Changed getJSON URL

### DIFF
--- a/data/Services.json
+++ b/data/Services.json
@@ -1746,12 +1746,6 @@
         "ref": "https://azure.microsoft.com/en-in/services/dns/",
         "icon": "Azure DNS.png",
         "Properties": [ "To be added", "To be added", "To be added", "To be added", "To be added" ]
-      },
-      {
-        "name": "Azure Traffic Manager",
-        "ref": "https://azure.microsoft.com/en-in/services/traffic-manager/",
-        "icon": "Azure Traffic Manager.png",
-        "Properties": [ "To be added", "To be added", "To be added", "To be added", "To be added" ]
       }
     ],
     "google": [
@@ -1787,7 +1781,65 @@
       }
     ]
   },
-
+ {
+    "category": {
+      "name": "Networking",
+      "ref": "http://#"
+    },
+    "service": {
+      "name": "Global Traffic Management",
+      "ref": "",
+      "Properties": [ "To be added", "To be added", "To be added", "To be added", "To be added" ]
+    },
+    "aws": [
+      {
+        "name": "Amazon Route 53 Traffic Flow",
+        "ref": "https://aws.amazon.com/blogs/aws/new-route-53-traffic-flow/",
+        "icon": "Networking_AmazonRoute53.png",
+        "Properties": [ "To be added", "To be added", "To be added", "To be added", "To be added" ]
+      }
+    ],
+    "azure": [
+      {
+        "name": "Azure Traffic Manager",
+        "ref": "https://azure.microsoft.com/en-in/services/traffic-manager/",
+        "icon": "Azure Traffic Manager.png",
+        "Properties": [ "To be added", "To be added", "To be added", "To be added", "To be added" ]
+      }
+    ],
+    "google": [
+      {
+        "name": "",
+        "ref": "#",
+        "icon": "none.png",
+        "Properties": [ "To be added", "To be added", "To be added", "To be added", "To be added" ]
+      }
+    ],
+    "ibm": [
+      {
+        "name": "",
+        "ref": "#",
+        "icon": "none.png",
+        "Properties": [ "Yes", "To be added", "To be added", "To be added", "To be added" ]
+      }
+    ],
+    "oracle": [
+      {
+        "name": "",
+        "ref": "#",
+        "icon": "none.png",
+        "Properties": [ "Yes", "To be added", "To be added", "To be added", "To be added" ]
+      }
+    ],
+    "alibaba": [
+      {
+        "name": "",
+        "ref": "#",
+        "icon": "none.png",
+        "Properties": [ "Yes", "To be added", "To be added", "To be added", "To be added" ]
+      }
+    ]
+  },
   {
     "category": {
       "name": "Networking & Content Delivery",

--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@ s.setAttribute('data-timestamp', +new Date());
       $(document).ready(function(){
       var trHTML = '';
 
-      $.getJSON('https://raw.githubusercontent.com/ilyas-it83/CloudComparer/master/data/Services.json', function (Json) {
+      $.getJSON('data/Services.json', function (Json) {
 
        //$.getJSON('https://raw.githubusercontent.com/BlueCodersDev/CloudComparer/master/data/Services.json', function (Json) {
       //$.getJSON('Data/Services.json', function (Json) {


### PR DESCRIPTION
Global Traffic Management is a different feature which is currently provided by AWS and Azure which is different from just DNS Resolution. So, I have added that.

Also, in the getJSON URL, the Service.json was from the main origin CDN of the repo, I changed that to the Service.json which is relative to the current directory so it is easier to check and changes on the local side.

Thanks
