### PR TITLE
Amazon EC2 Bare Metal Instance is not anymore in preview

### DIFF
--- a/data/Services.json
+++ b/data/Services.json
@@ -260,8 +260,8 @@
         },
         "aws": [
             {
-                "name": "Amazon EC2 Bare Metal Instance (Preview)",
-                "ref": "https://aws.amazon.com/blogs/aws/new-amazon-ec2-bare-metal-instances-with-direct-access-to-hardware/",
+                "name": "Amazon EC2 Bare Metal Instance",
+                "ref": "https://aws.amazon.com/blogs/aws/category/compute/amazon-ec2-bare-metal/",
                 "icon": "aws.png",
                 "Properties": [
                     "39",


### PR DESCRIPTION
Amazon EC2 Bare Metal Instance is not in preview since a may 2018 https://aws.amazon.com/about-aws/whats-new/2018/05/announcing-general-availability-of-amazon-ec2-bare-metal-instances/