### PR TITLE
Update ElasticSearch Service for AWS

### DIFF
--- a/data/Services.json
+++ b/data/Services.json
@@ -3906,8 +3906,8 @@
 				"icon": "Arch_Amazon-CloudSearch_64.png"
 			},
 			{
-				"name": "Amazon Elastic Search Service",
-				"ref": "https://aws.amazon.com/elasticsearch-service/",
+				"name": "Amazon Open Search Service",
+				"ref": "https://aws.amazon.com/opensearch-service/",
 				"icon": "Arch_Amazon-Elasticsearch-Service_64.png"
 			}
 		],


### PR DESCRIPTION
Amazon announced that their new service offering for ElasticSearch will be their engine support for OpenSearch and replaces it with the latter