### PR TITLE
Fixed broken link

### DIFF
--- a/_data/cloudservices.yml
+++ b/_data/cloudservices.yml
@@ -1188,7 +1188,7 @@ services:
             icon: Microsoft Azure.png
       - google:
           - name: Migrate for Compute Engine
-            ref: https://cloud.google.com/migrate/compute-engine",
+            ref: https://cloud.google.com/migrate/compute-engine,
             icon: Generic-GCP.png
           - name: Migrate for Anthos
             ref: https://cloud.google.com/migrate/anthos


### PR DESCRIPTION
The link for `https://cloud.google.com/migrate/compute-engine` was being rendered with the `<a` markup in the screen due to a problem in the url (`ref`) definition.