### PR TITLE
Update cloudservices.yml

### DIFF
--- a/_data/cloudservices.yml
+++ b/_data/cloudservices.yml
@@ -1056,9 +1056,6 @@ services:
           - name: Amazon DynamoDB
             ref: https://aws.amazon.com/dynamodb/
             icon: Database_AmazonDynamoDB.png
-          - name: Amazon Managed Service for Prometheus (Preview)
-            ref: https://aws.amazon.com/prometheus/
-            icon: Arch_Amazon-Managed-Service-for-Prometheus_64.png
           - name: Amazon Timestream
             ref: https://aws.amazon.com/timestream/
             icon: aws.png
@@ -3732,7 +3729,7 @@ services:
     service:
       - aws:
           - name: Amazon API Gateway
-            ref:
+            ref: https://aws.amazon.com/api-gateway/
             icon: Application-Services_AmazonAPIGateway.png
       - azure:
           - name: Azure API Management
@@ -4235,7 +4232,7 @@ services:
     service:
       - aws:
           - name: Amazon Pinpoint
-            ref:
+            ref: https://aws.amazon.com/pinpoint/
             icon: aws.png
       - azure:
           - name: Mobile Engagement
@@ -4269,7 +4266,7 @@ services:
     service:
       - aws:
           - name: Amazon SES
-            ref:
+            ref: https://aws.amazon.com/ses/
             icon: Application-Services_AmazonSES_email.png
       - azure:
           - name:
@@ -4303,7 +4300,7 @@ services:
     service:
       - aws:
           - name: Amazon SNS
-            ref:
+            ref: https://aws.amazon.com/sns/
             icon: Mobile-Services_AmazonSNS.png
       - azure:
           - name: Azure Notification Services
@@ -4539,7 +4536,7 @@ services:
     service:
       - aws:
           - name: AWS Marketplace
-            ref:
+            ref: https://aws.amazon.com/marketplace
             icon: aws.png
       - azure:
           - name: Azure MarketPlace
@@ -4572,7 +4569,7 @@ services:
     service:
       - aws:
           - name: AWS IoT Platform
-            ref:
+            ref: https://aws.amazon.com/iot/
             icon: Internet-Of-Things_AWSIoT.png
       - azure:
           - name: Azure IoT Platform
@@ -4624,7 +4621,7 @@ services:
     service:
       - aws:
           - name: AWS Greengrass
-            ref:
+            ref: https://aws.amazon.com/greengrass/
             icon: aws.png
       - azure:
           - name: Azure IoT SDK
@@ -4700,7 +4697,7 @@ services:
     service:
       - aws:
           - name: AWS IoT Button
-            ref:
+            ref: https://aws.amazon.com/iotbutton/
             icon: aws.png
       - azure:
           - name: Azure Sphere


### PR DESCRIPTION
AWS updates. Removed 1 misplaced service and updated links for 8  services

- removed "Amazon Managed Service for Prometheus (Preview)" from Timeseries Database as the service is not a time series DB, it's monitoring as a service. This service is already properly placed within the "Logging & Monitoring"
- Added link for "AWS IoT Button"
- Added link for "AWS Greengrass"
- Added link for "AWS IoT Platform"
- Added link for "AWS Marketplace"
- Added link for "Amazon SNS"
- Added link for "Amazon SES"
- Added link for "Amazon Pinpoint"
- Added link for "API Gateway"