### PR TITLE
PR to update from certificate manager to secrets manager service

### DIFF
--- a/_data/cloudservices.yml
+++ b/_data/cloudservices.yml
@@ -2600,8 +2600,8 @@ services:
             ref:
             icon: none.png
       - ibm:
-          - name: Certificate Manager
-            ref: https://cloud.ibm.com/catalog/services/certificate-manager
+          - name: Secrets Manager
+            ref: https://cloud.ibm.com/catalog/services/secrets-manager
             icon: ibmcloud.png
       - oracle:
           - name:


### PR DESCRIPTION
Certificate Manager is in the process of being withdrawn from service and are eligible to be removed after the deprecation period. For more information about the deprecation of this service, see the doc:

[certificate-manager-release-notes](https://cloud.ibm.com/docs/certificate-manager?topic=certificate-manager-release-notes)

The new service is:
[secrets-manager](https://cloud.ibm.com/catalog/services/secrets-manager)