### PR TITLE
Additional category for Azure Analysis Services

### DIFF
--- a/_data/cloudservices.yml
+++ b/_data/cloudservices.yml
@@ -3196,9 +3196,12 @@ services:
             ref: https://quicksight.aws/
             icon: Analytics_AmazonQuickSight.png
       - azure:
-          - name: PowerBI
+          - name: Power BI
             ref: https://powerbi.microsoft.com/
             icon: Power BI Embedded.png
+          - name: Azure Analysis Service
+            ref: https://docs.microsoft.com/azure/analysis-services/
+            icon: Azure Machine Learning.png
       - google:
           - name: Google Data Studio
             ref: https://cloud.google.com/data-studio/


### PR DESCRIPTION
@ilyas-it83 , as per the request in #146 have added Azure Analysis Services as one of the Azure product for Business Intelligence & Data Visualization.

This categorisation seems the most appropriate subcategory for this in the business intelligence area:
https://docs.microsoft.com/en-us/azure/analysis-services/