### PR TITLE
GCP BigTable url fix

### DIFF
--- a/_data/cloudservices.yml
+++ b/_data/cloudservices.yml
@@ -1080,7 +1080,7 @@ services:
             icon: Azure DocumentDB.png
       - google:
           - name: Cloud Bigtable
-            ref: https://cloud.google.com/Bigtable/
+            ref: https://cloud.google.com/bigtable/
             icon: Cloud-Bigtable.png
       - ibm:
           - name: Informix


### PR DESCRIPTION
BigTable url is case sensitive

https://cloud.google.com/Bigtable/ page is 404 not found